### PR TITLE
Mitgliedsanträge ohne Realnamen erlauben

### DIFF
--- a/Statuten_Funkfeuer_Wien.md
+++ b/Statuten_Funkfeuer_Wien.md
@@ -88,7 +88,7 @@ ernannt werden.
 
 2. Juristische Personen und rechtsfähige Personengesellschaften können ausschließlich die fördernde oder außerordentliche Mitgliedschaft erwerben.
 
-3. Der Antrag auf Mitgliedschaft erfolgt durch Einbringung eines vollständig ausgefüllten und unterzeichneten Mitgliedsantrages. Die Einbringung kann per Post an die Vereinsadresse oder persönlich an den Schriftführer oder von diesem legitimierte Personen erfolgen. 
+3. Der Antrag auf Mitgliedschaft erfolgt durch Einbringung eines mit mindestens einem Pseudonym sowie einer Kontaktmöglichkeit ausgefüllten und unterzeichneten Mitgliedsantrages. Die Einbringung kann per Post an die Vereinsadresse oder persönlich an den Schriftführer oder von diesem legitimierte Personen erfolgen. 
 Mit Eingang des Antrages wird der Werber automatisch als außerordentliches Mitglied aufgenommen.
 Über die Aufnahme von ordentlichen, außerordentlichen und fördernden Mitgliedern entscheidet der Vorstand innerhalb einer Frist von 6 Monaten. Die Aufnahme kann ohne Angabe von Gründen verweigert werden.
 


### PR DESCRIPTION
Ich beantrage hiermit, bei der nächsten Generalversammlung die dargestellte Änderung an den Statuen zu beschließen, um die bereits vielfach praktizierte anonyme Teilnahme am Funknetz auch formal zu erlauben.