### PR TITLE
Aufnahme außerordentliche Mitglieder automatisch oder Vorstandsentscheid?

### DIFF
--- a/Statuten_Funkfeuer_Wien.md
+++ b/Statuten_Funkfeuer_Wien.md
@@ -90,7 +90,7 @@ ernannt werden.
 
 3. Der Antrag auf Mitgliedschaft erfolgt durch Einbringung eines vollständig ausgefüllten und unterzeichneten Mitgliedsantrages. Die Einbringung kann per Post an die Vereinsadresse oder persönlich an den Schriftführer oder von diesem legitimierte Personen erfolgen. 
 Mit Eingang des Antrages wird der Werber automatisch als außerordentliches Mitglied aufgenommen.
-Über die Aufnahme von ordentlichen, außerordentlichen und fördernden Mitgliedern entscheidet der Vorstand innerhalb einer Frist von 6 Monaten. Die Aufnahme kann ohne Angabe von Gründen verweigert werden.
+Über die Aufnahme von ordentlichen und fördernden Mitgliedern entscheidet der Vorstand innerhalb einer Frist von 6 Monaten. Die Aufnahme kann ohne Angabe von Gründen verweigert werden.
 
 4. Die Ernennung zum Ehrenmitglied erfolgt auf Antrag des Vorstands durch die Generalversammlung.
 


### PR DESCRIPTION
Sollen außerordentliche Mitglieder automatisch mit der Abgabe eines Antrags aufgenommen werden, oder erst per Vorstandsentscheid? Beides zusammen wirkt auf mich Widersprüchlich.

Ich beantrage hiermit die Streichung der Aufnahme von außerordentlichen Mitgliedern per Vorstandsentscheid, sodass nur die automatische Aufnahme bei Abgabe eines Mitgliedsantrags übrig bleibt.

Bei vorliegen von Gründen die gegen eine Mitgliedschaft des außerordentlichen Mitglieds trifft, kann dieses dann anschließend wieder ausgeschlossen werden. Aber bei automatischer Aufnahme kann nicht anschließend nochmal per Vorstandsbeschluss über die Aufnahme entschieden werden.